### PR TITLE
Fix generating dangling library doc comment

### DIFF
--- a/lib/src/twirp_file_generator.dart
+++ b/lib/src/twirp_file_generator.dart
@@ -90,7 +90,7 @@ class TwirpFileGenerator extends FileGenerator {
 
   /// Writes the header at the top of the dart file.
   void _writeHeading(IndentingWriter out) {
-    out.println('///');
+    out.println('//');
     out.println('//  Generated code. Do not modify.');
     out.println('//  source: ${descriptor.name}');
     out.println('//');


### PR DESCRIPTION
Analyzer is complaining about `dangling_library_doc_comments`